### PR TITLE
eid-packer-centos8-integ.qcow2:

### DIFF
--- a/qemu.py/eid-packer-centos8-integ.qcow2
+++ b/qemu.py/eid-packer-centos8-integ.qcow2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d17c12700b8f6ea2a84b7343dacaf2243e731988c96f658ae099542e3562e8b
-size 1137421312
+oid sha256:fede481552939da79ceaf8f7f5d2640959b3e2efdb79bccb54a9064abf33a5b3
+size 1191575552


### PR DESCRIPTION
Added rpm install of libdwarves and dwarves 1.19